### PR TITLE
corrected typo in method

### DIFF
--- a/Python/datenbank.py
+++ b/Python/datenbank.py
@@ -393,7 +393,7 @@ class Datenbank:
         """
         try:
             self.deleteFutureActivity(userId, activity)
-            self.setFutureStatus(userId, activity, status)
+            self.setDoneStatus(userId, activity, status)
         except mysql.connector.errors.Error as e:
             raise
 


### PR DESCRIPTION
Ich hatte einen Tippfehler in der Methode moveFutureActivityToDone. Da wurde ausversehen eine falsche Methode aufgerufen